### PR TITLE
Made Project::SLUG_PATTERN case insensitive

### DIFF
--- a/src/Gitonomy/Bundle/CoreBundle/Entity/Project.php
+++ b/src/Gitonomy/Bundle/CoreBundle/Entity/Project.php
@@ -17,7 +17,7 @@ use Gitonomy\Git\Repository;
 
 class Project
 {
-    const SLUG_PATTERN = '[a-z0-9-_]+';
+    const SLUG_PATTERN = '[a-zA-Z0-9-_]+';
 
     protected $id;
     protected $name;


### PR DESCRIPTION
git clone/pull/push fail with `Command seems illegal: git-(receive|upload)-pack` when there is uppercase characters in projects slugs.

This can be fixed by changing `Project::SLUG_PATTERN` to `[a-zA-Z0-9-_]+` as done in this PR, or by adding the `i` flag to this regex : https://github.com/gitonomy/gitonomy/blob/master/src/Gitonomy/Bundle/CoreBundle/Command/GitCommand.php#L96
