### PR TITLE
[WIP] Allow subfolders

### DIFF
--- a/features/project/create.feature
+++ b/features/project/create.feature
@@ -26,6 +26,29 @@ Feature: Project creation
           And I should see 1 "xpath=//table[contains(@class, 'git-accesses')]/tbody/tr/td[contains(., 'Developer')]"
           And I should see 1 "xpath=//table[contains(@class, 'git-accesses')]/tbody/tr/td[contains(., 'Visitor')]"
 
+    Scenario: A user creates a new project with a directory separator in slug
+        Given project "foo/bar" does not exist
+        And I am connected as "alice"
+        And I am on "/"
+
+         When I click on "Create a new project"
+          And I fill:
+            | Name of project | foo/bar |
+            | Slug of project | foo/bar |
+            | Default branch | master |
+          And I click on "Create"
+         Then I should see "Project created"
+
+         When I am on "/projects/foo/bar"
+         Then I should see "How to make your first commit"
+          And user "alice" is "Lead developer" on "foo/bar"
+
+         When I click on "Permissions"
+         Then I should see "Git accesses"
+          And I should see 1 "xpath=//table[contains(@class, 'git-accesses')]/tbody/tr/td[contains(., 'Lead developer')]"
+          And I should see 1 "xpath=//table[contains(@class, 'git-accesses')]/tbody/tr/td[contains(., 'Developer')]"
+          And I should see 1 "xpath=//table[contains(@class, 'git-accesses')]/tbody/tr/td[contains(., 'Visitor')]"
+
     Scenario: An anonymous cannot create a project
         Given I am on "/create-project"
          Then I should see "Login"
@@ -39,11 +62,29 @@ Feature: Project creation
           And I click on "Create"
          Then I should see "This value is already used."
 
-    Scenario: A user cannot create a project with invalid slug
+    Scenario: A user cannot create a project with invalid slug (directory separator at first)
         Given I am connected as "alice"
          When I am on "/create-project"
           And I fill:
             | Name of project | toto |
-            | Slug of project | to/to |
+            | Slug of project | /toto |
+          And I click on "Create"
+         Then I should see "This value is not valid."
+
+    Scenario: A user cannot create a project with invalid slug (directory separator at end)
+        Given I am connected as "alice"
+         When I am on "/create-project"
+          And I fill:
+            | Name of project | toto |
+            | Slug of project | toto/ |
+          And I click on "Create"
+         Then I should see "This value is not valid."
+
+    Scenario: A user cannot create a project with invalid slug (directory separator doubled)
+        Given I am connected as "alice"
+         When I am on "/create-project"
+          And I fill:
+            | Name of project | toto |
+            | Slug of project | to//to |
           And I click on "Create"
          Then I should see "This value is not valid."

--- a/src/Gitonomy/Bundle/CoreBundle/Entity/Project.php
+++ b/src/Gitonomy/Bundle/CoreBundle/Entity/Project.php
@@ -17,7 +17,7 @@ use Gitonomy\Git\Repository;
 
 class Project
 {
-    const SLUG_PATTERN = '[a-zA-Z0-9-_/]+';
+    const SLUG_PATTERN = '(?:[a-zA-Z0-9-_]+/?)*[a-zA-Z0-9-_]';
 
     protected $id;
     protected $name;

--- a/src/Gitonomy/Bundle/CoreBundle/Entity/Project.php
+++ b/src/Gitonomy/Bundle/CoreBundle/Entity/Project.php
@@ -17,7 +17,7 @@ use Gitonomy\Git\Repository;
 
 class Project
 {
-    const SLUG_PATTERN = '[a-zA-Z0-9-_]+';
+    const SLUG_PATTERN = '[a-zA-Z0-9-_/]+';
 
     protected $id;
     protected $name;

--- a/src/Gitonomy/Bundle/WebsiteBundle/Resources/config/routing/project.yml
+++ b/src/Gitonomy/Bundle/WebsiteBundle/Resources/config/routing/project.yml
@@ -6,78 +6,112 @@ project_create:
     pattern: /create-project
     defaults: { _controller: "GitonomyWebsiteBundle:Project:create" }
 
-project_newsfeed:
-    pattern: /projects/{slug}
-    defaults: { _controller: "GitonomyWebsiteBundle:Project:newsfeed" }
-
 project_history:
     pattern: /projects/{slug}/history
     defaults: { _controller: "GitonomyWebsiteBundle:Project:history" }
+    requirements:
+        slug: .+
 
 project_source:
     pattern: /projects/{slug}/source
     defaults: { _controller: "GitonomyWebsiteBundle:Project:source" }
+    requirements:
+        slug: .+
 
 project_branches:
     pattern: /projects/{slug}/branches
     defaults: { _controller: "GitonomyWebsiteBundle:Project:branches" }
+    requirements:
+        slug: .+
 
 project_tags:
     pattern: /projects/{slug}/tags
     defaults: { _controller: "GitonomyWebsiteBundle:Project:tags" }
+    requirements:
+        slug: .+
 
 project_commit:
     pattern: /projects/{slug}/commits/{hash}
     defaults: { _controller: "GitonomyWebsiteBundle:Project:commit" }
+    requirements:
+        slug: .+
 
 project_tree:
     pattern: /projects/{slug}/tree/{revision}/{path}
     defaults: { _controller: "GitonomyWebsiteBundle:Project:tree", path: "" }
-    requirements: { path: ".*" }
+    requirements:
+        path: .*
+        slug: .+
 
 project_blame:
     pattern: /projects/{slug}/blame/{revision}/{path}
     defaults: { _controller: "GitonomyWebsiteBundle:Project:blame", path: "" }
-    requirements: { path: ".*" }
+    requirements:
+        path: .*
+        slug: .+
 
 project_tree_history:
     pattern: /projects/{slug}/tree-history/{revision}/{path}
     defaults: { _controller: "GitonomyWebsiteBundle:Project:treeHistory", path: "" }
-    requirements: { path: ".*" }
+    requirements:
+        path: .*
+        slug: .+
 
 project_compare:
     pattern: /projects/{slug}/compare/{revision}
     defaults: { _controller: "GitonomyWebsiteBundle:Project:compare" }
+    requirements:
+        slug: .+
 
 project_permissions:
     pattern: /projects/{slug}/permissions
     defaults: { _controller: "GitonomyWebsiteBundle:Project:permissions" }
-    requirements: { _method: GET }
+    requirements:
+        _method: GET
+        slug: .+
 
 project_postPermissionsCreateRole:
     pattern: /projects/{slug}/permissions/role
     defaults: { _controller: "GitonomyWebsiteBundle:Project:postPermissionsCreateRole" }
-    requirements: { _method: POST }
+    requirements:
+        _method: POST
+        slug: .+
 
 project_postPermissionsDeleteRole:
     pattern: /projects/{slug}/permissions/role/{id}/delete
     defaults: { _controller: "GitonomyWebsiteBundle:Project:postPermissionsDeleteRole" }
-    requirements: { _method: POST }
+    requirements:
+        _method: POST
+        slug: .+
 
 project_postPermissionsCreateGitAccess:
     pattern: /projects/{slug}/permissions/git-access
     defaults: { _controller: "GitonomyWebsiteBundle:Project:postPermissionsCreateGitAccess" }
-    requirements: { _method: POST }
+    requirements:
+        _method: POST
+        slug: .+
 
 project_postPermissionsDeleteGitAccess:
     pattern: /projects/{slug}/permissions/git-access/{id}/delete
     defaults: { _controller: "GitonomyWebsiteBundle:Project:postPermissionsDeleteGitAccess" }
-    requirements: { _method: POST }
+    requirements:
+        _method: POST
+        slug: .+
 
 project_admin:
     pattern: /projects/{slug}/admin
     defaults: { _controller: "GitonomyWebsiteBundle:Project:admin" }
+    requirements:
+        slug: .+
 
 project_delete:
     pattern: /projects/{slug}/admin/remove
     defaults: { _controller: "GitonomyWebsiteBundle:Project:delete" }
+    requirements:
+        slug: .+
+
+project_newsfeed:
+    pattern: /projects/{slug}
+    defaults: { _controller: "GitonomyWebsiteBundle:Project:newsfeed" }
+    requirements:
+        slug: .+


### PR DESCRIPTION
This PR add the possibility to specify subfolders for slug project.
e.g. `foo/bar`

**In progress**
- ~~Check that slug project doesn't go outside of configured repositories directory~~ (see d448c7bf021a9d0c058c028eaadc879301fa6e5f)
- ~~Add some tests~~ (see 9dd5b45c8259b8dee8df24f1182bacdd4f6c926b)

**Known bugs**
- Bad links generated by `git_url()` twig function (Function in `gitonomy/git-bundle`)
