### PR TITLE
Remove the "updateToken" call

### DIFF
--- a/src/Gitonomy/Bundle/CoreBundle/Entity/UserForgotPassword.php
+++ b/src/Gitonomy/Bundle/CoreBundle/Entity/UserForgotPassword.php
@@ -22,11 +22,7 @@ class UserForgotPassword
     public function __construct(User $user, $token = null, \DateTime $createdAt = null)
     {
         $this->user      = $user;
-        if (null === $token) {
-            $this->updateToken();
-        } else {
-            $this->setToken($token, $createdAt);
-        }
+        $this->setToken($token, $createdAt);
     }
 
     public function setToken($token = null, \DateTime $createdAt = null)


### PR DESCRIPTION
The method `updateToken` does not exist and is useless: The method `setToken` checks (and creates if necessary) the token and the created date.

This PR solves the issue #68.
