### PR TITLE
Check if it is possible to reinitialize the password twice or more

### DIFF
--- a/features/splash/forgot_password.feature
+++ b/features/splash/forgot_password.feature
@@ -29,3 +29,49 @@ Feature: Forgot your password
             | Confirm password | alice |
           And I click on "Reset password"
          Then I should see "conscientiously saved"
+
+  Scenario: I can reinitialize my password twice or more
+        Given I am on "/"
+         When I click on "Forgot your password?"
+          And I fill:
+            | Email | alice@example.org |
+          And I click on "Send a mail with a link"
+         Then I should see "We send a mail with instructions. Read it, and click, now!"
+          And 1 mail should be sent
+         When I open mail to "alice@example.org"
+         Then I should see "requested to change the password" in mail
+         When I click on "/forgot-password/" in mail
+         Then I should see "Change your password"
+         When I fill:
+            | Password       | new |
+            | Password again | new |
+          And I click on "Change your password"
+         Then I should see "successfully been changed"
+         When I purge mails
+          And I click on "Forgot your password?"
+          And I fill:
+            | Email | alice@example.org |
+          And I click on "Send a mail with a link"
+         Then I should see "We send a mail with instructions. Read it, and click, now!"
+          And 1 mail should be sent
+         When I open mail to "alice@example.org"
+         Then I should see "requested to change the password" in mail
+         When I click on "/forgot-password/" in mail
+         Then I should see "Change your password"
+         When I fill:
+            | Password       | new2 |
+            | Password again | new2 |
+          And I click on "Change your password"
+         Then I should see "successfully been changed"
+         When I fill:
+            | Username | alice |
+            | Password | new2 |
+          And I click on "Login"
+         Then I should see "Projects"
+         When I am on "/profile/password"
+          And I fill:
+            | Current password | new2 |
+            | Password         | alice |
+            | Confirm password | alice |
+          And I click on "Reset password"
+         Then I should see "conscientiously saved"


### PR DESCRIPTION
I added a test to check the issue #43. It passed, so I suppose the issue #43 has been fixed.

The `UserForgotPassword` has not an expiration time: if the token is not `null`, the token will be considered as valid.

The relation between `User` and `UserForgotPassword` has not to be changed:
- if `User` has not an `UserForgotPassword`, the system will create it.
- if `User` has a `UserForgotPassword`, the system will use it.

In all cases, a new `token` will be generated.
